### PR TITLE
prevent existing registry key error

### DIFF
--- a/Observer/AfterImportProductData.php
+++ b/Observer/AfterImportProductData.php
@@ -111,6 +111,9 @@ class AfterImportProductData implements ObserverInterface
                         $data[$newSku['entity_id']] = $stockItem;
                     }
                 }
+                if ($this->registry->registry(InventoryLogHelper::MOVEMENT_DATA)) {
+                    $this->registry->unregister(InventoryLogHelper::MOVEMENT_DATA);
+                }
                 $this->registry->register(InventoryLogHelper::MOVEMENT_DATA, $data);
             }
         }


### PR DESCRIPTION
If you upload multiple rows via Magento default import an error is thrown:

![image](https://user-images.githubusercontent.com/7961978/144576003-ecceeecc-7ed3-4fdd-8b19-42390b85e17b.png)

The fix for this is provided by https://magento.stackexchange.com/a/348869/41707 ❤️

I am not sure if this is a smart way to fix, but at least I can confirm that it works.