### PR TITLE
Handle credit memo items without a valid product in refund observer

### DIFF
--- a/Observer/RefundOrderInventoryObserver.php
+++ b/Observer/RefundOrderInventoryObserver.php
@@ -19,6 +19,7 @@ use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Type as ProductType;
 use Elgentos\InventoryLog\Helper\Data as InventoryLogHelper;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class RefundOrderInventoryObserver implements ObserverInterface
 {
@@ -87,7 +88,11 @@ class RefundOrderInventoryObserver implements ObserverInterface
             $itemsToUpdate = [];
             foreach ($creditmemo->getAllItems() as $item) {
                 $productId = $item->getProductId();
-                $product = $this->productRepositoryInterface->getById($productId);
+                try {
+                    $product = $this->productRepositoryInterface->getById($productId);
+                } catch (NoSuchEntityException $e) {
+                    continue;
+                }
                 $productType = $product->getTypeId();
                 $qty = $item->getQty();
 
@@ -101,7 +106,7 @@ class RefundOrderInventoryObserver implements ObserverInterface
                             $oldQty = $stockItem->getQty() - $qty;
                             $stockItem->setOldQty($oldQty);
                         }
-                        
+
                         $msg = __('Product restocked after credit memo creation (credit memo: %s)');
                         $message = sprintf(
                             $msg,


### PR DESCRIPTION
This fixes https://github.com/elgentos/magento2-inventory-log/issues/10

When a product is deleted after it has been ordered, the ProductRepository will throw an exception when trying to load the product for the credit memo item. Because this exception is never caught in the RefundOrderInventoryObserver, this results in a bug where you can't refund orders for products that have been deleted.

Catching the exception makes sure that the observer does not interfere with the refund process. Since there will be no stock for a credit memo item whose product has been deleted, we can just `continue`.