### PR TITLE
Add the properties, because otherwise product page breaks.

### DIFF
--- a/Model/MovementRepository.php
+++ b/Model/MovementRepository.php
@@ -83,6 +83,8 @@ class MovementRepository implements MovementRepositoryInterface
      */
     public $productMetadata;
 
+    public CollectionProcessorInterface $collectionProcessor;
+
     /**
      * MovementRepository constructor.
      * @param ResourceMovement $resource

--- a/Observer/Backend/Hyva/GridSourcePrefetchInventoryLogGrid.php
+++ b/Observer/Backend/Hyva/GridSourcePrefetchInventoryLogGrid.php
@@ -8,6 +8,12 @@ use Magento\Framework\Api\SearchCriteriaInterface;
 
 class GridSourcePrefetchInventoryLogGrid implements \Magento\Framework\Event\ObserverInterface
 {
+    private FilterBuilder $filterBuilder;
+
+    private FilterGroupBuilder $filterGroupBuilder;
+
+    private \Magento\Framework\Registry $registry;
+    
     public function __construct(
         FilterBuilder $filterBuilder,
         FilterGroupBuilder $filterGroupBuilder,


### PR DESCRIPTION
When no properties are declared, the product page displays the following error:
```
Deprecated Functionality: Creation of dynamic property Elgentos\InventoryLog\Observer\Backend\Hyva\GridSourcePrefetchInventoryLogGrid::$filterBuilder is deprecated in vendor/elgentos/magento2-inventory-log/Observer/Backend/Hyva/GridSourcePrefetchInventoryLogGrid.php on line 16
```

And during saving the following error message:
```
Deprecated Functionality: Creation of dynamic property Elgentos\InventoryLog\Model\MovementRepository::$collectionProcessor is deprecated in vendor/elgentos/magento2-inventory-log/Model/MovementRepository.php on line 121
```

This pull request prevents that.