### PR TITLE
Added support for stock updates via REST api

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -23,6 +23,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const STOCK_UPDATE = 1;
     const ORDER_CANCEL = 2;
     const CREDIT_MEMO = 3;
+    const WEBAPI_STOCK_UPDATE = 4;
+
     const MOVEMENT_SECTION = "movement_section";
     const NEW_PRODUCT = "new_product";
     const MOVEMENT_DATA = "movement_data";

--- a/Plugin/Stock/StockItemRepository.php
+++ b/Plugin/Stock/StockItemRepository.php
@@ -108,6 +108,12 @@ class StockItemRepository
                     $message = __('Product restocked after order cancellation');
                 }
                 $this->movementRepository->insertStockMovement($stockItem, $message);
+            } elseif ($movementSection === InventoryLogHelper::WEBAPI_STOCK_UPDATE) {
+                $message = __('Stock updated via WebAPI');
+                $stockAutoFlag = $stockItem->getStockStatusChangedAutomaticallyFlag();
+                if (!$stockAutoFlag || $stockItem->getOldQty() != $stockItem->getQty() || $newProduct == 1) {
+                    $this->movementRepository->insertStockMovement($stockItem, $message, $newProduct);
+                }
             }
             $this->helper->unRegisterAllData();
         }

--- a/Plugin/Webapi/Stock/StockItemRepository.php
+++ b/Plugin/Webapi/Stock/StockItemRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Elgentos\InventoryLog\Plugin\Webapi\Stock;
+
+class StockItemRepository
+{
+    public function __construct(
+        public \Magento\Framework\Registry $registry,
+        public \Elgentos\InventoryLog\Helper\Data $helper
+    ) {}
+
+    public function beforeSave(
+        $subject,
+        \Magento\CatalogInventory\Api\Data\StockItemInterface $stockItem
+    ): array {
+        if (!$this->helper->isModuleEnabled()) {
+            return [$stockItem];
+        }
+
+        $this->registry->register(
+            \Elgentos\InventoryLog\Helper\Data::MOVEMENT_SECTION,
+            \Elgentos\InventoryLog\Helper\Data::WEBAPI_STOCK_UPDATE
+        );
+
+        return [$stockItem];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,7 +15,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\CatalogInventory\Model\Stock\StockItemRepository">
-        <plugin name="update_stockitem_ukey" type="Elgentos\InventoryLog\Plugin\Stock\StockItemRepository" sortOrder="1" disabled="false"/>
+        <plugin name="update_stockitem_ukey" type="Elgentos\InventoryLog\Plugin\Stock\StockItemRepository" sortOrder="2" disabled="false"/>
     </type>
 
     <preference for="Magento\CatalogImportExport\Model\Import\Product"

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\CatalogInventory\Model\Stock\StockItemRepository">
+        <plugin name="update_stockitem_via_webapi" type="Elgentos\InventoryLog\Plugin\Webapi\Stock\StockItemRepository"
+                sortOrder="1"
+                disabled="false"/>
+    </type>
+</config>


### PR DESCRIPTION
Hi @peterjaap!

First of all, thanks for the module! For one of our clients I needed to register updates via the REST WebAPI as well. Instead of creating an extended module, I thought it might be useful for other people as well.

This change adds support for stock mutations executed via the REST-webapi (no support for the GraphQL API, sorry). I tried to make my changes in the code style of the original module, but I'm open for any feedback. Let me know what you think!