### PR TITLE
Move catalog_product_save_before to adminhtml area

### DIFF
--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -3,4 +3,8 @@
     <event name="hyva_grid_source_prefetch_inventory_log_grid">
         <observer name="elgentos_inventorylog_hyva_grid_source_prefetch_inventory_log_grid" instance="\Elgentos\InventoryLog\Observer\Backend\Hyva\GridSourcePrefetchInventoryLogGrid"/>
     </event>
+    
+    <event name="catalog_product_save_before">
+        <observer name="kiwicommerce_inventory" instance="Elgentos\InventoryLog\Observer\SaveInventoryDataObserver"/>
+    </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -14,9 +14,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="catalog_product_save_before">
-        <observer name="kiwicommerce_inventory" instance="Elgentos\InventoryLog\Observer\SaveInventoryDataObserver"/>
-    </event>
 
     <event name="checkout_submit_all_after">
         <observer name="kiwicommerce_order_place" instance="Elgentos\InventoryLog\Observer\CheckoutAllSubmitAfter" />


### PR DESCRIPTION
Fix #21 

This PR moves the catalog_product_save_before event observer to adminhtml, so it does not conflict with the rest API stock update.